### PR TITLE
Attempt to add ABTesting.js as a standalone lib.

### DIFF
--- a/switchboard/abtesting.html
+++ b/switchboard/abtesting.html
@@ -11,7 +11,7 @@
   <div id="app">Look at the console</div>
   <script src="ABTesting.js"></script>
   <script>
-      console.log(ABTesting.isEnabled({min: "5", max: "15"}));
+      console.log(ABTesting.isEnabled({buckets: {min: "5", max: "15"}}));
   </script>
 </body>
 </html>

--- a/switchboard/abtesting.html
+++ b/switchboard/abtesting.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ABTesting</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="app">Look at the console</div>
+  <script src="ABTesting.js"></script>
+  <script>
+      console.log(ABTesting.isEnabled({min: "5", max: "15"}));
+  </script>
+</body>
+</html>

--- a/switchboard/package.json
+++ b/switchboard/package.json
@@ -4,8 +4,9 @@
   "description": "Demo app of the switchboard feature.",
   "scripts": {
     "dist": "NODE_ENV=production webpack --optimize-minimize --config webpack.prod.js && cp index.prod.html dist/index.html",
+    "ab_testing": "NODE_ENV=production webpack --config webpack.abtesting.dist.js --optimize-minimize && cp abtesting.html dist/",
     "lint": "eslint src test",
-    "publish-to-gh-pages": "rimraf build && PUBLIC_PATH='/switchboard-experiments-kinto/' npm run dist && bin/switchboard build -d build && gh-pages --dist build/",
+    "publish-to-gh-pages": "rimraf build && PUBLIC_PATH='/switchboard-experiments-kinto/' npm run dist && npm run ab_testing && bin/switchboard build -d build && gh-pages --dist build/",
     "start": "NODE_ENV=development node devServer.js",
     "tdd": "NODE_ENV=test babel-node node_modules/.bin/_mocha --require ./test/setup-jsdom.js 'test/**/*_test.js' --watch",
     "test": "NODE_ENV=test babel-node node_modules/.bin/_mocha --require ./test/setup-jsdom.js 'test/**/*_test.js'"

--- a/switchboard/webpack.abtesting.dist.js
+++ b/switchboard/webpack.abtesting.dist.js
@@ -12,22 +12,19 @@ module.exports = {
     libraryTarget: "umd"
   },
   plugins: [
-    new webpack.IgnorePlugin(/^(buffertools)$/), // unwanted "deeper" dependency
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify("production")
       }
     })
   ],
-  node: {
-    Buffer: "mock",
-  },
   devtool: "source-map",
   module: {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ["babel"],
+        exclude: [/node_modules/],
+        loaders: ["babel-loader"],
       }
     ]
   }

--- a/switchboard/webpack.abtesting.dist.js
+++ b/switchboard/webpack.abtesting.dist.js
@@ -1,0 +1,34 @@
+var webpack = require("webpack");
+
+module.exports = {
+  cache: true,
+  context: __dirname + "/src",
+  entry: "./ab_testing.js",
+  output: {
+    path: "./dist",
+    publicPath: "/dist/",
+    filename: "ABTesting.js",
+    library: "ABTesting",
+    libraryTarget: "umd"
+  },
+  plugins: [
+    new webpack.IgnorePlugin(/^(buffertools)$/), // unwanted "deeper" dependency
+    new webpack.DefinePlugin({
+      "process.env": {
+        NODE_ENV: JSON.stringify("production")
+      }
+    })
+  ],
+  node: {
+    Buffer: "mock",
+  },
+  devtool: "source-map",
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loaders: ["babel"],
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Apparently it doesn't work yet as expected.

@n1k0 Anyidea?

Deploy on gh-pages: http://mozilla-services.github.io/switchboard-experiments-kinto/abtesting.html
